### PR TITLE
cleaning up relpath to config

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -801,7 +801,12 @@ def relpath_to_config_or_make(filename):
 
     # Relative path in the dist directory.
     prefix = _find_prefix(filename)
-    return os.path.relpath(os.path.dirname(filename), prefix)
+    rel_path = os.path.relpath(os.path.dirname(filename), prefix)
+    if '../' in rel_path and is_darwin:
+        sp_path = os.path.relpath(os.path.abspath(rel_path), os.path.expanduser('~'))
+    else:
+        sp_path = os.path.relpath(os.path.dirname(filename), prefix)
+    return sp_path
 
 
 def copy_metadata(package_name):


### PR DESCRIPTION
This change checks if the relative path to the config or make file contains `../` if it does and it is on a darwin platform it converts the path to absolute and removes the users home directory from the path.